### PR TITLE
Add language toggle to error message.

### DIFF
--- a/src/apiCalls/apiCalls.js
+++ b/src/apiCalls/apiCalls.js
@@ -1,9 +1,9 @@
 const handleError = (response) => {
   if(!response.ok) {
-    throw new Error(`Error: ${response.status} -- Please refresh the page.`)
-  }
-  return response.json()
-}
+    throw new Error(`${response.status}`)
+  };
+  return response.json();
+};
 
 const getData = async(url) => {
   let response = await fetch(url, {
@@ -12,9 +12,9 @@ const getData = async(url) => {
       'X-RapidAPI-Key': 'bc9c0e8e5fmshb0c38a31a8522adp1e5430jsn80040d7c0eb8',
       'X-RapidAPI-Host': 'tank01-mlb-live-in-game-real-time-statistics.p.rapidapi.com'
     }
-  })
-  let data = await handleError(response)
-  return data
-}
+  });
+  let data = await handleError(response);
+  return data;
+};
 
-export default getData
+export default getData;

--- a/src/components/EmptyState/EmptyState.js
+++ b/src/components/EmptyState/EmptyState.js
@@ -1,10 +1,17 @@
 import './EmptyState.css';
 import PropTypes from 'prop-types';
+import { useLanguage } from '../../context/LanguageContext';
 
 const EmptyState = ({ errorMessage }) => {
+  const { language } = useLanguage();
+
   return (
     <div className="error-message-container">
-      <h2 className="error-message">{errorMessage.includes('Failed') ? 'Error 500 -- Please try again' : errorMessage}</h2>
+      <h2 className="error-message">
+          {language === 'en' 
+          ? `An error: ${errorMessage} occurred -- please refresh the page` 
+          : `Ocurrio un error nivel ${errorMessage} -- por favor actualiza la pagina`}
+        </h2>
     </div>
   )
 };


### PR DESCRIPTION
Closes #34 

What I did:
Corrected error message toggle for Spanish language: previously, 500 and 400 level errors were ony displaying in English. 

Testing Notes/Extras: 

Did this break anything?
- [x]  No
- [ ]  Yes

Type of change
- [x]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:
- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing